### PR TITLE
Added support for ROSS, REXUTIL, and WESTERMAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The following cartridge types are currently supported:
 * Drean
 * C128 Generic cartridge (external function ROM)
 * WarpSpeed 128
+* Ross Cartridge
+* Westerman Learning System
+* Rex Utility
 
 ## Supported File Types
 

--- a/firmware/cartridges/cartridge.c
+++ b/firmware/cartridges/cartridge.c
@@ -37,6 +37,8 @@ static u32 freezer_state;
 #include "simons_basic.c"
 #include "super_games.c"
 #include "epyx_fastload.c"
+#include "westerman.c"
+#include "rexutil.c"
 #include "c64gs_system_3.c"
 #include "warpspeed.c"
 #include "dinamic.c"
@@ -44,6 +46,7 @@ static u32 freezer_state;
 #include "magic_desk.c"
 #include "super_snapshot_5.c"
 #include "comal80.c"
+#include "ross.c"
 #include "easyflash.c"
 #include "easyflash_3.c"
 #include "prophet64.c"
@@ -106,6 +109,15 @@ static void (*crt_get_handler(u32 cartridge_type, bool vic_support)) (void)
 
         case CRT_COMAL_80:
             return comal80_handler;
+
+	    case CRT_ROSS:
+	        return ross_handler;
+
+        case CRT_REX_UTILITY:
+            return rexutil_handler;
+        
+        case CRT_WESTERMANN_LEARNING:
+            return westerman_handler;
 
         case CRT_OCEAN_TYPE_1:
         case CRT_EASYFLASH:
@@ -177,6 +189,18 @@ static void crt_init(CFG_CRT_HEADER *crt_header)
 
         case CRT_COMAL_80:
             comal80_init();
+            break;
+
+        case CRT_ROSS:
+            ross_init();
+            break;
+
+        case CRT_REX_UTILITY:
+            rexutil_init();
+            break;
+
+        case CRT_WESTERMANN_LEARNING:
+            westerman_init();
             break;
 
         case CRT_EASYFLASH:

--- a/firmware/cartridges/rexutil.c
+++ b/firmware/cartridges/rexutil.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019-2024 Kim Jørgensen and Sven Oliver (SvOlli) Moll
+ * Copyright (c) 2024 Vladan Nikolic
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/*
+Hardware ID: 12 (rexutil)
+
+    CRT_REX_UTILITY
+
+*/
+
+/*
+    - 8kb ROM
+
+    - reading df00-dfbf disables ROM
+    - reading dfc0-dfff enables ROM (8k game config)
+*/
+
+
+/*************************************************
+* C64 bus read callback
+*************************************************/
+FORCE_INLINE bool rexutil_read_handler(u32 control, u32 addr)
+{
+    if ((control & (C64_ROML)) != (C64_ROML))
+    {
+        C64_DATA_WRITE(crt_ptr[addr & 0x1fff]);
+        return true;
+    }
+
+    /* IO and ROM access */
+    if (!(control & C64_IO2))
+    {
+        // Read to IO2: 00-bf disables rom, c0-ff Switch to 8K mode
+		if ((addr & 0xff) < 0xc0)
+		{
+		
+			C64_CRT_CONTROL(STATUS_LED_OFF|CRT_PORT_NONE);
+		
+		} else {
+		
+			C64_CRT_CONTROL(STATUS_LED_ON|CRT_PORT_8K);
+		}
+        return true;
+    }
+
+
+
+    return false;
+}
+
+/*************************************************
+* C64 bus write callback
+*************************************************/
+FORCE_INLINE void rexutil_write_handler(u32 control, u32 addr, u32 data)
+{
+
+    // No support for write
+
+}
+
+static void rexutil_init()
+{
+
+    C64_CRT_CONTROL(STATUS_LED_ON|CRT_PORT_8K);
+}
+
+C64_BUS_HANDLER(rexutil)

--- a/firmware/cartridges/ross.c
+++ b/firmware/cartridges/ross.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019-2024 Kim Jørgensen and Sven Oliver (SvOlli) Moll
+ * Copyright (c) 2024 Vladan Nikolic
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/*
+Hardware ID: 23 (ROSS)
+Hardware Revision: 0
+Mode: exrom: 0 game: 0 (16k Game)
+
+offset  sig  type  bank start size  chunklen
+$000040 CHIP ROM   #000 $8000 $4000 $4010
+
+total banks: 1 size: $004000
+*/
+
+/*
+ * Ross has an easy hardware setup
+ * - a single 16k bank that can be turned on or off
+ * - read $DE00-$DFFF will switch banks if 32k image == NOT IMPLEMENTED
+ * - read $DF00-$DFFF turns ROM off
+ */
+
+/*************************************************
+* C64 bus read callback
+*************************************************/
+FORCE_INLINE bool ross_read_handler(u32 control, u32 addr)
+{
+    if ((control & (C64_ROML|C64_ROMH)) != (C64_ROML|C64_ROMH))
+    {
+        C64_DATA_WRITE(crt_ptr[addr & 0x3fff]);
+        return true;
+    }
+    
+    /* IO and ROM access */
+    if (!(control & C64_IO2))
+    {
+        // Any read to IO2: Disable ROM
+        C64_CRT_CONTROL(STATUS_LED_OFF|CRT_PORT_NONE);
+        return true;   
+    }
+
+    if (!(control & C64_IO1))
+    {
+        // Any read to IO1: Switch bank
+        crt_ptr = crt_banks[1];
+        return false;
+    }
+
+    return false;
+}
+
+/*************************************************
+* C64 bus write callback
+*************************************************/
+FORCE_INLINE void ross_write_handler(u32 control, u32 addr, u32 data)
+{
+
+    // No support for write
+    
+}
+
+static void ross_init()
+{
+    
+    // C64_CRT_CONTROL(STATUS_LED_ON|CRT_PORT_16K);
+}
+
+C64_BUS_HANDLER(ross)

--- a/firmware/cartridges/westerman.c
+++ b/firmware/cartridges/westerman.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019-2024 Kim Jørgensen and Sven Oliver (SvOlli) Moll
+ * Copyright (c) 2024 Vladan Nikolic
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/*
+Hardware ID: 11 (westerman)
+
+    CRT_WESTERMANN_LEARNING
+
+
+*/
+
+/*
+    16kb ROM
+
+    - starts in 16k game config
+    - any read access to io2 switches to 8k game config
+
+ */
+
+/*************************************************
+* C64 bus read callback
+*************************************************/
+FORCE_INLINE bool westerman_read_handler(u32 control, u32 addr)
+{
+    if ((control & (C64_ROML|C64_ROMH)) != (C64_ROML|C64_ROMH))
+    {
+        C64_DATA_WRITE(crt_ptr[addr & 0x3fff]);
+        return true;
+    }
+
+    /* IO and ROM access */
+    if (!(control & C64_IO2))
+    {
+        // Any read to IO2: Switch to 8K mode
+        C64_CRT_CONTROL(STATUS_LED_OFF|CRT_PORT_8K);
+        return true;
+    }
+
+
+
+    return false;
+}
+
+/*************************************************
+* C64 bus write callback
+*************************************************/
+FORCE_INLINE void westerman_write_handler(u32 control, u32 addr, u32 data)
+{
+
+    // No support for write
+
+}
+
+static void westerman_init()
+{
+
+    C64_CRT_CONTROL(STATUS_LED_ON|CRT_PORT_16K);
+}
+
+C64_BUS_HANDLER(westerman)


### PR DESCRIPTION
I have implemented support for Ross, Rex Utility, and Westerman Learning CRTs which are common in Eastern Europe